### PR TITLE
Add Sierra to Owners and Maintainers

### DIFF
--- a/CODEOWNERS.md
+++ b/CODEOWNERS.md
@@ -1,2 +1,2 @@
 # CODEOWNERS
-* @shanewholloway-usds-2 @alain-owen-kuchta
+* @shanewholloway-usds-2 @alain-owen-kuchta @sierrabrandtFSA

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,4 +6,5 @@ This is a list of maintainers for this project. See CODEOWNERS for list of revie
 |:-----|:-----|:-----|:-----|
 | Maintainer | Shane Holloway | @shanewholloway-usds-2 | U.S. Digital Service |
 | Maintainer | Alain Kuchta   | @alain-owen-kuchta | U.S. Digital Service |
+| Maintainer | Sierra Brandt  | @sierrabrandtFSA | FSA Digital Service |
 


### PR DESCRIPTION
This PR adds Sierra Brand (FSA DS) to the list of code owners and maintainers for this repo.